### PR TITLE
allow options to be preselected

### DIFF
--- a/jquery.chained.js
+++ b/jquery.chained.js
@@ -54,9 +54,12 @@
                     $(self).trigger("change");
                 });
                 
-                /* Force IE to see something selected on first page load. */
-                $("option", this).first().attr("selected", "selected");
-                
+                /* Force IE to see something selected on first page load, */
+                /* Unless something is already selected */
+                if ( !$("option:selected", this).length ) {
+                    $("option", this).first().attr("selected", "selected");
+                }
+	    
                 /* Force updating the children. */
                 $(this).trigger("change");             
 


### PR DESCRIPTION
If options were preselected in the HTML, they were being ignored and the first option was being selected.  This change causes the first option to be selected only if no options have been marked as selected.
