### PR TITLE
Support for json as array

### DIFF
--- a/jquery.chained.remote.js
+++ b/jquery.chained.remote.js
@@ -31,6 +31,7 @@
                     });
                     
                     $.getJSON(url, data, function(json) {
+                        var selected_key = $(':selected', self).val();
 
                         /* Clear the select. */
                         $("option", self).remove();
@@ -49,7 +50,6 @@
                         }
 
                         /* Add new options from json. */
-                        var selected_key = null;
                         var options_len = option_list.length;
                         for (var i=0; i<options_len; i+=1) {
                             /* This sets the default selected. */


### PR DESCRIPTION
I needed to present a large list of options and preserve server-side ordering.

With this patch, json may be either an array of [key, value] tuples, or an object of {key: value}.
