### PR TITLE
For a multiples chaines select

### DIFF
--- a/jquery.chained.js
+++ b/jquery.chained.js
@@ -18,6 +18,8 @@
     
     $.fn.chained = function(parent_selector, options) {
         
+        var iniId = this.attr('id');
+        
         var settings = $.extend( {}, $.fn.chained.defaults, options);
         
         return this.each(function() {
@@ -30,6 +32,11 @@
             $(parent_selector).each(function() {
                                                 
                 $(this).bind("change", function() {
+                    
+                    if(iniId !== undefined)
+                		if($(self).attr('id') != iniId)
+            				return;
+                    
                     $(self).html(backup.html());
 
                     /* If multiple parents build classname like foo\bar. */


### PR DESCRIPTION
This changes allow you to use one select and then chained it to a multiples select, in case you need multiple selectors depending on one. eg. In a e-commerce you select the Main size group, then each new model depends on this group but have individual sizes.
