### PR TITLE
Added option for defining a custom parameter name for remote chained

### DIFF
--- a/jquery.chained.remote.js
+++ b/jquery.chained.remote.js
@@ -37,7 +37,7 @@
                     $(parent_selector).each(function() {
                         
                         var id;
-                        if(options.paramName){
+                        if(options.hasOwnProperty(paramName)){
                             id = options.paramName;
                         }else{
                             id = $(this).attr(settings.attribute);


### PR DESCRIPTION
I needed to specifiy a custom parameter name instead of using the select field id when doing server request with the remote chained version of the plugin.
I just use the already defined options variable and pass a parameter called paramName. Then before the remote request I check the presence of the option. If is defined use that value. Otherwise fallbacks to the original method
I think this adds some more flexibility. I dont know about the variable name "paramName".  I dont like it that much but i couldnt think any better. 
