### PR TITLE
Don't trigger change event unnecessarily

### DIFF
--- a/jquery.chained.js
+++ b/jquery.chained.js
@@ -81,7 +81,7 @@
                 $("option", child).each(function() {
                     /* Remove unneeded items but save the default value. */
                     if ($(this).hasClass(selected) && $(this).val() === currently_selected_value) {
-                        $(this).prop('selected', true);
+                        $(this).prop("selected", true);
                         trigger_change = false;
                     } else if (!$(this).hasClass(selected) && !$(this).hasClass(selected_first) && $(this).val() !== "") {
                         $(this).remove();


### PR DESCRIPTION
When initialising the selects, do go through and narrow down the child
options based on currently selected parents, but do so using a function
rather than triggering change on the parents.

Also don’t trigger a change event on the child during normal use if the
parent changes but the selected child option exists in the new set of
options. Instead just re-select it and leave it at that.

Also cleaned up some stuff and used clearer variable names in places.
