### PR TITLE
Set the name of the request variable, to avoid unnecessary requests, and more

### DIFF
--- a/jquery.chained.remote.js
+++ b/jquery.chained.remote.js
@@ -62,8 +62,20 @@
                         }
                     });
 
+                    /* Clear the select. */
+                    $("option", self).remove();
+
+                    /* Force updating the children to clear too. */
+                    $(self).trigger("change");
+
                     /* Do not execute remote request if the data is empty.. */
                     if (!$.isEmptyObject(data)) {
+
+                        /* Fill the select with loading message. */
+                        if (settings.loading) {
+                            build.call(self, settings.loading);
+                        }
+
                         $.getJSON(settings.url, data, function (json) {
                             build.call(self, json);
                             /* Force updating the children. */
@@ -141,7 +153,8 @@
         attribute: "name",
         varName : null,
         depends : null,
-        bootstrap : null
+        bootstrap : null,
+        loading: {null:"Loading..."}
     };
 
 })(window.jQuery || window.Zepto, window, document);


### PR DESCRIPTION
Option to set the variable name that will be used in the request.
Do not execute remote request if the data is empty.
Tell that the field is being loaded.
Clear fields children when the parent is changed
