### PR TITLE
Update jquery.chained.remote.js

### DIFF
--- a/jquery.chained.remote.js
+++ b/jquery.chained.remote.js
@@ -28,6 +28,14 @@
             settings.parents = parents;
             settings.url = url;
         }
+        
+        var compare = function (a, b) {
+            if (a[1] < b[1])
+                return -1;
+            if (a[1] > b[1])
+                return 1;
+            return 0;
+        }
 
         return this.each(function() {
 
@@ -113,6 +121,10 @@
                             option_list.push([index, json[index]]);
                         }
                     }
+                }
+                if(settings.hasOwnProperty('orderby') && 'value' == settings.orderby)
+                {
+                    option_list.sort(compare);
                 }
 
                 /* Add new options from json. */


### PR DESCRIPTION
this changes will alowed to orger results by select option text

there is a syntax how to use new option:
$("#series").remoteChained({
  parents : "#mark",
  url : "/api/series.json",
  orderby: 'value'
});

this is common usability to order results by option text.

For example selects car makes and models.
Makes and models must be ordereb by names not by his database ids.
