### PR TITLE
Get value from <select> or <input>

### DIFF
--- a/jquery.chained.remote.js
+++ b/jquery.chained.remote.js
@@ -42,7 +42,7 @@
                     var data = {};
                     $(settings.parents).each(function() {
                         var id = $(this).attr(settings.attribute);
-                        var value = $(":selected", this).val();
+                        var value = ($(this).is("select") ? $(":selected", this) : $(this)).val();
                         data[id] = value;
 
                         /* Optionally also depend on values from these inputs. */


### PR DESCRIPTION
Today, we can only have "select" fields as parents. 
There may be cases where a parent field is a hidden input.
