### PR TITLE
Added support for an url callback function

### DIFF
--- a/jquery.chained.remote.js
+++ b/jquery.chained.remote.js
@@ -74,7 +74,10 @@
                         $(self).trigger("change");
                     }
 
-                    request = $.getJSON(settings.url, data, function(json) {
+                    /* If the supplied url option is a function execute it, otherwise use the given url */
+                    var url = ($.isFunction(settings.url)) ? settings.url() : settings.url;
+
+                    request = $.getJSON(url, data, function(json) {
                         build.call(self, json);
                         /* Force updating the children. */
                         $(self).trigger("change");


### PR DESCRIPTION
I needed a way to add custom parameters to the url based on the value of other input fields. This little change makes it possible to pass a callback function to the url option which should return the url without breaking backwards compatibility.

example:

```javascript
$('#select2').remoteChainedTo({
   parents: '#select1',
   url: function() {
      var url = '/api/endpoint';
      var otherInput = $('#otherInput').val();
      if (otherInput != '') {
         url += '?customParam='+otherInput;
      }
      return url;
   }
});
```

If you like this functionality but its missing something or you would like to see it implemented in some other way let me know and I will make some time to look into it.
