### PR TITLE
Adds the trasform callback that create the option from key and value

### DIFF
--- a/jquery.chained.remote.js
+++ b/jquery.chained.remote.js
@@ -105,7 +105,7 @@
                             if ("selected" === key) {
                                 selectedKey = value;
                             } else {
-                                var option = $("<option />").val(key).append(value);
+                                var option = settings.transform(key,value);
                                 $(self).append(option);
                             }
                         });
@@ -119,7 +119,7 @@
                             if ("selected" === key) {
                                 selectedKey = value;
                             } else {
-                                var option = $("<option />").val(key).append(value);
+                                var option = settings.transform(key,value);
                                 $(self).append(option);
                             }
                         }
@@ -153,7 +153,10 @@
         bootstrap: null,
         loading: null,
         clear: false,
-        data: function(json) { return json; }
+        data: function(json) { return json; },
+        transform: function (key, value) {
+            return $("<option />").val(key).append(value);
+        }
     };
 
 })(window.jQuery || window.Zepto, window, document);


### PR DESCRIPTION
Can be used to modify the option.
By default, the options can have just a value and a label,
but in this way `data` properties can be added or we can apply other transformations.

For example when I change an option, 
I could load the associated image, or check if that item is a leaf or it has children, without having to launch a request, but using the data from the json response I get on change.
