### PR TITLE
Add extra type cast to String before call split()

### DIFF
--- a/jquery.chained.js
+++ b/jquery.chained.js
@@ -76,7 +76,7 @@
                     var matches = [];
                     var data = String($(this).data("chained"));
                     if (data) {
-                        matches = data.split(" ");
+                        matches = String(data).split(" ");
                     }
                     if ((matches.indexOf(selected) > -1) || (matches.indexOf(selectedFirst) > -1)) {
                         if ($(this).val() === currentlySelectedValue) {


### PR DESCRIPTION
Fix bug when call split() on number
Similar to this PR https://github.com/tuupola/jquery_chained/pull/74 but he changed the minified version