### PR TITLE
#69 Add callback function to remote chained.

### DIFF
--- a/jquery.chained.remote.js
+++ b/jquery.chained.remote.js
@@ -79,6 +79,7 @@
                         build.call(self, json);
                         /* Force updating the children. */
                         $(self).trigger("change");
+                        settings.callback(self);
                     });
                 });
 
@@ -153,6 +154,7 @@
         bootstrap: null,
         loading: null,
         clear: false,
+        callback: function() {},
         data: function(json) { return json; }
     };
 


### PR DESCRIPTION
Would still need compiling into min and probably also this change: https://github.com/tuupola/jquery_chained/pull/69/commits/2f68092e145e52e9b90356675e078654552c4598

Using it something like this:

    var setDefaultFromUrl = function(select) {
      console.log('executed');
    };
    
    $("#all-downloads-service-pack").remoteChained({
      parents : "#all-downloads-version",
      url : '/service-pack',
      callback: setDefaultFromUrl
    });